### PR TITLE
Обработаны некоторые ошибки

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -128,14 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-.idea/$CACHE_FILE$
-.idea/.gitignore
-.idea/aiogram-bot-template.iml
-.idea/codeStyles/
-.idea/deployment.xml
-.idea/dictionaries
-.idea/inspectionProfiles/
-.idea/misc.xml
-.idea/modules.xml
-.idea/vagrant.xml
-.idea/vcs.xml
+.idea/

--- a/handlers/groups/moderate_chat.py
+++ b/handlers/groups/moderate_chat.py
@@ -1,55 +1,76 @@
 import asyncio
 import datetime
 from aiogram import types
+from aiogram.utils.exceptions import BadRequest
 
 from loader import bot, dp
 from aiogram.dispatcher.filters import Command, AdminFilter
 from filters import IsGroup
 
+import logging
 
-# Хендлер с фильтром в группе, где можно использовать команду !ro ИЛИ /ro
+
 @dp.message_handler(IsGroup(), AdminFilter(), Command(commands=["ro"], prefixes="!/"))
 async def read_only_mode(message: types.Message):
+    """
+    Хендлер с фильтром в группе, где можно использовать команду !ro ИЛИ /ro
+
+    :time int: время на которое нужно замутить пользователя в минутах
+    :reason str: причина мута
+
+    Примеры:
+
+    Простейший мут на 5 минут:
+        !ro 5
+        или
+        /ro 5
+
+    Мут на 50 минут с причиной мута:
+        !ro 50 читай мануал
+        или
+        /ro 50 читай мануал
+    """
     member = message.reply_to_message.from_user.id
-    chat = message.chat.id
     command, time, *comment = message.text.split(' ')
-    # Пример 1
-    # !ro 5
-    # command='!ro' time='5' comment=[]
-
-    # Пример 2
-    # !ro 50 читай мануал
-    # command='!ro' time='50' comment=['читай', 'мануал']
-
-    time = int(time)
 
     # Получаем конечную дату, до которой нужно забанить
-    until_date = datetime.datetime.now() + datetime.timedelta(minutes=time)
+    until_date = datetime.datetime.now() + datetime.timedelta(minutes=int(time))
 
-    # Вариант 1 - по API
-    # await bot.restrict_chat_member(chat_id=chat, user_id=member,  can_send_messages=False, until_date=until_date)
+    try:
+        # Пытаемся забрать права у пользователя
+        await message.chat.restrict(user_id=member, can_send_messages=False, until_date=until_date)
+        comment = " ".join(comment)
+        await message.answer(
+            f"Пользователю {message.reply_to_message.from_user.full_name} запрещено писать {time} минут.\n"
+            f"По причине: \n<b>{comment}</b>"
+        )
+        # Вносим информацию о муте в лог
+        logging.info(
+            f"Пользователью @{message.reply_to_message.from_user.full_name} запрещено писать сообщения до {until_date}"
+        )
+        service_message = await message.reply("Сообщение самоуничтожится через 5 секунд.")
+        # Если удалось успешно замутить пользователя, ждём 5 секунд
+        await asyncio.sleep(5)
+        # а после удаляем сообщение, на которое ссылался администратор, при муте
+        await message.reply_to_message.delete()
 
-    # Вариант 2 - сокращенный
-    await message.chat.restrict(user_id=member, can_send_messages=False, until_date=until_date)
-
-    comment = " ".join(comment)
-
-    # Пишем в чат
-    await message.answer(f"Пользователю {message.reply_to_message.from_user.full_name} запрещено писать {time} минут.\n"
-                         f"По причине: \n<b>{comment}</b>")
-
-    service_message = await message.reply("Сообщение самоуничтожится через 5 секунд.")
-    # Пауза 5 сек
-    await asyncio.sleep(5)
-
-    # Удаляем сообщения
-    # Вариант 1 - по API
-    # await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
-
-    # Вариант 2 - сокращенный
-    await message.reply_to_message.delete()
-    await message.delete()
-    await service_message.delete()
+    # Если бот не может забанить пользователя (администратора), возникает ошибка BadRequest которую мы обрабатываем
+    except BadRequest:
+        service_message = await message.answer(
+            "Пользователь является администратором чата, я не могу выдать ему RO\n"
+            "Сообщение самоуничтожится через 5 секунд.",
+            reply=True
+        )
+        # Вносим информацию о муте в лог
+        logging.info(
+            f"Бот не смог замутить пользователя @{message.reply_to_message.from_user.full_name}"
+        )
+        await asyncio.sleep(5)
+        # Опять ждём перед выполнением следующего блока
+    finally:
+        # после прошедших 5 секунд, бот удаляет сообщение от администратора и от самого бота
+        await message.delete()
+        await service_message.delete()
 
 
 @dp.message_handler(IsGroup(), AdminFilter(), Command(commands=["unro"], prefixes="!/"))

--- a/utils/notify_admins.py
+++ b/utils/notify_admins.py
@@ -1,6 +1,7 @@
 import logging
 
-from aiogram import Dispatcher, types
+from aiogram import Dispatcher
+from aiogram.utils.exceptions import ChatNotFound
 
 from data.config import admins
 
@@ -9,7 +10,8 @@ async def mail_to_admins(dp):
     for admin in admins:
         try:
             await dp.bot.send_message(admin, "Бот Запущен и готов к работе с группами!")
-
+        except ChatNotFound:
+            logging.info("Chat with admin not found")
         except Exception as err:
             logging.exception(err)
 


### PR DESCRIPTION
Обработаны ошибки, возникающие при:
* отправке сообщения о работе бота всем администраторам. В случае, если бот не сможет отправить, в консоль придёт не вся ошибка, а только лог о том, что сообщение отправить не удалось
* ro на администратора. Теперь бот пишет в чат, что не способен забанить администратора и не удаляет сообщение, на которое ссылались при муте.
Полностью передокументированна комманда /ro. Добавлено логгирование к ней же